### PR TITLE
Better pdf table names

### DIFF
--- a/messytables/pdf.py
+++ b/messytables/pdf.py
@@ -21,9 +21,9 @@ class PDFTableSet(TableSet):
     def tables(self):
         def table_name(table):
             return "Table {0} of {1} on page {2} of {3}".format(
-                table.table_number_on_page,
+                table.table_number_on_page + 1,
                 table.total_tables_on_page,
-                table.page_number,
+                table.page_number + 1,
                 table.total_pages)
         return [PDFRowSet(table_name(table), table)
                 for table in self.raw_tables]


### PR DESCRIPTION
Fixes an indexing / display bug where tables extracted from PDFs would have a `name` attribute of something weird like `Table 0 of 1 on page 0 of 3`.

No tests because I couldn't work out how to get my environment set up, and my lunchtime timebox was up (I created a `virtualenv`, activated, and then pip installed `requirements-test.txt`, but `nosetest` still skipped the two pdf tests at the end of `test/test_read.py`)

If somebody could run the tests and confirm this works, then merge it, that'd be really handy. This bug is currently blocking this ticket in the Table Xtract tool: https://github.com/scraperwiki/magic-table-scraper-tool/issues/219
