### PR TITLE
handle application-xml mimetype as HTML not XLS

### DIFF
--- a/messytables/any.py
+++ b/messytables/any.py
@@ -62,7 +62,7 @@ def guess_mime(mimetype):
               'application/vnd.ms-excel': 'XLS',
               'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'XLS',
               'text/html': 'HTML',
-              'application/xml': 'XLS',
+              'application/xml': 'HTML', # XHTML is often served as application-xml
               'application/pdf': 'PDF',
               'text/plain': 'CSV',  # could be TAB.
               'application/CDFV2-corrupt': 'XLS',


### PR DESCRIPTION
We've encountered XHTML files being served with an `application-xml` mimetype. Messytables treated these files as XLS files, and then raised an error about:

```
Unsupported format, or corrupt file: Expected BOF record; found \
```

This pull request makes messytables treat `application-xml` files as HTML files not XLS files.

As far as I can tell, all the tests continue to pass.
